### PR TITLE
Add a new endpoint (#57)

### DIFF
--- a/api/proxy.md
+++ b/api/proxy.md
@@ -32,31 +32,6 @@ Each item in any of those arrays is a project, and follows this format:
 }
 ```
 
-## `/proxy/users`
+## `GET /proxy/users`
 
-### `GET /proxy/users/<name>/activity`
-
-Gets activity events that appear in the user's activity feed. Returns an array of [activity event objects](definitions/activity_event_object.md).
-
-### `GET /proxy/users/<name>/activity/count`
-
-Gets the number of messages the user has, in this format:
-
-```
-{
-    "msg_count": /* Messages the user currently has */
-}
-```
-
-(This endpoint is deprecated in favor of [`/users/<name>/messages/count`](users.md#get-usersusernamemessagescount).)
-
-### `GET /proxy/users/<id>/featured`
-
-Gets projects on the homepage that are featured to user personally. Returns an object of which each of its properties' values are arrays of project objects:
-
-```
-{
-    "custom_projects_by_following": /* Projeted by users the user is following */
-    "custom_projects_loved_by_following": /* Projects loved by users the user is following */
-}
-```
+All of the `/proxy/users` endpoints have been replaced by new endpoints in [/users](users.md).  

--- a/api/users.md
+++ b/api/users.md
@@ -38,11 +38,15 @@ Gets a list of projects that have recently been added to studios that the given 
 
 ### `GET /users/<username>/following/users/loves`
 
-Gets a list of projects that have recently been loved by users that the given user is following. Returns an array of [project objects](definitions/project_object.md). [Requires authentication.](../etc/authentication.md)
+Gets a list of projects that have recently been loved by users that the given user is following. Shows up as "Projects Loved by Scratchers I'm Following" on the front page.  Returns an array of [project objects](definitions/project_object.md). [Requires authentication.](../etc/authentication.md)
 
 ### `GET /users/<username>/following/users/projects`
 
 Gets a list of projects that have recently been shared by users that the given user is following. Returns an array of [project objects](definitions/project_object.md). [Requires authentication.](../etc/authentication.md)
+
+### `GET /users/<username>/following/users/activity`
+
+Gets events that show up in the "What's Happening" feed on the front page.  Returns an array of [activity event objects](definitions/activity_event_object.md).  [Requires authentication.](../etc/authentication.md)
 
 ### `GET /users/<username>/messages`
 


### PR DESCRIPTION
* Correct a depreciated endpoint

* Add GET /users/<username>/following/users/activity

* A better depreciation notice

* Revert "A better depreciation notice"

This reverts commit 092ba7a91aae3d87ec5a05258c66d8d4776b1c80.

* Revert "Correct a depreciated endpoint"

This reverts commit 0db46e7847319f3c4ba5e221d7107b586a1ad99c.

* Clarify GET /users/<username>/following/users/activity

* Add that an an endpoint requires authentication

* Added extra information to /users/<username>/following/users/loves

* Depreciated all /proxy/users endpoints